### PR TITLE
Replace various hardcoded paths

### DIFF
--- a/src/main/java/com/articulate/nlp/DependencyConverter.java
+++ b/src/main/java/com/articulate/nlp/DependencyConverter.java
@@ -82,12 +82,12 @@ public class DependencyConverter {
         BufferedWriter _writer; 
         BufferedReader _error;
         String tmpfname = "tmp.txt";
-//        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_25/bin/java -mx1000m -classpath " + System.getProperty("user.home") + "/Programs/stanford-parser-full-2014-08-27" + 
+//        String execString = System.getProperty("java.home") + "/java -mx1000m -classpath " + System.getProperty("user.home") + "/Programs/stanford-parser-full-2014-08-27" + 
         String stanfordCore = System.getProperty("user.home") + "/Programs/stanford-corenlp-full-2015-12-09";
         String newcore = KBmanager.getMgr().getPref("stanford-core");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;
-        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_60/bin/java -mx1000m -classpath " + stanfordCore +
+        String execString = System.getProperty("java.home") + "/java -mx1000m -classpath " + stanfordCore + 
                 "/stanford-corenlp-3.5.1.jar edu.stanford.com.articulate.nlp.parser.lexparser.LexicalizedParser " +
                 "-outputFormat typedDependencies " + stanfordCore + "/englishPCFG-mcg.ser.gz " + tmpfname;
                 //"-outputFormat typedDependencies " + System.getProperty("user.home") + "/Programs/stanford-parser-full-2014-08-27/englishPCFG.ser.gz " + tmpfname;
@@ -153,7 +153,7 @@ public class DependencyConverter {
         String newcore = KBmanager.getMgr().getPref("stanford-core");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;
-        String execString = "java -classpath " + stanfordCore + 
+        String execString = System.getProperty("java.home") + "/java -classpath " + stanfordCore + 
                 "/stanford-parser.jar edu.stanford.com.articulate.nlp.process.DocumentPreprocessor " +
                 infile;
         System.out.println("INFO in DependencyConverter.splitSentences(): executing: " + execString);

--- a/src/main/java/com/articulate/nlp/DependencyConverter.java
+++ b/src/main/java/com/articulate/nlp/DependencyConverter.java
@@ -82,15 +82,15 @@ public class DependencyConverter {
         BufferedWriter _writer; 
         BufferedReader _error;
         String tmpfname = "tmp.txt";
-//        String execString = "/home/apease/Programs/java/jdk1.8.0_25/bin/java -mx1000m -classpath /home/apease/Programs/stanford-parser-full-2014-08-27" + 
-        String stanfordCore = "/home/apease/Programs/stanford-corenlp-full-2015-01-30";
+//        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_25/bin/java -mx1000m -classpath " + System.getProperty("user.home") + "/Programs/stanford-parser-full-2014-08-27" + 
+        String stanfordCore = System.getProperty("user.home") + "/Programs/stanford-corenlp-full-2015-12-09";
         String newcore = KBmanager.getMgr().getPref("stanford-core");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;
-        String execString = "/home/apease/Programs/java/jdk1.8.0_60/bin/java -mx1000m -classpath " + stanfordCore +
+        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_60/bin/java -mx1000m -classpath " + stanfordCore +
                 "/stanford-corenlp-3.5.1.jar edu.stanford.com.articulate.nlp.parser.lexparser.LexicalizedParser " +
                 "-outputFormat typedDependencies " + stanfordCore + "/englishPCFG-mcg.ser.gz " + tmpfname;
-                //"-outputFormat typedDependencies /home/apease/Programs/stanford-parser-full-2014-08-27/englishPCFG.ser.gz " + tmpfname;
+                //"-outputFormat typedDependencies " + System.getProperty("user.home") + "/Programs/stanford-parser-full-2014-08-27/englishPCFG.ser.gz " + tmpfname;
         FileWriter fr = null;
         PrintWriter pr = null;
 
@@ -149,7 +149,7 @@ public class DependencyConverter {
         BufferedReader _reader; 
         BufferedWriter _writer; 
         BufferedReader _error;
-        String stanfordCore = "/home/apease/Programs/stanford-corenlp-full-2015-01-30";
+        String stanfordCore = System.getProperty("user.home") + "/Programs/stanford-corenlp-full-2015-12-09";
         String newcore = KBmanager.getMgr().getPref("stanford-core");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;

--- a/src/main/java/com/articulate/nlp/LinearRegression.java
+++ b/src/main/java/com/articulate/nlp/LinearRegression.java
@@ -88,7 +88,7 @@ public class LinearRegression {
     public static void run() {
 
         DocGen dg = DocGen.getInstance();
-        ArrayList<ArrayList<String>> input = dg.readSpreadsheetFile("/home/apease/IPsoft/NB/LRdata.csv", ',');
+        ArrayList<ArrayList<String>> input = dg.readSpreadsheetFile(System.getProperty("user.home") + "/IPsoft/NB/LRdata.csv", ',');
         input.remove(0);  // eliminate the "start" line that DocGen adds in
         if (input.size() < 1)
             System.out.println("Error no rows in file");

--- a/src/main/java/com/articulate/nlp/NGramOverlap.java
+++ b/src/main/java/com/articulate/nlp/NGramOverlap.java
@@ -146,7 +146,7 @@ public class NGramOverlap {
         TokenOverlap to = null;
         NGramOverlap ng = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             ng = new NGramOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/NGramOverlap.java
+++ b/src/main/java/com/articulate/nlp/NGramOverlap.java
@@ -146,7 +146,7 @@ public class NGramOverlap {
         TokenOverlap to = null;
         NGramOverlap ng = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             ng = new NGramOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/NaiveBayes.java
+++ b/src/main/java/com/articulate/nlp/NaiveBayes.java
@@ -55,7 +55,7 @@ public class NaiveBayes {
 
         DocGen dg = DocGen.getInstance();
         if (StringUtil.emptyString(filename))
-            input = dg.readSpreadsheetFile("/home/apease/IPsoft/NB/NBdata.txt", ',');
+            input = dg.readSpreadsheetFile(System.getProperty("user.home") + "/IPsoft/NB/NBdata.txt", ',');
         else
             input = dg.readSpreadsheetFile(filename, ',');
         //System.out.println(input);
@@ -404,8 +404,8 @@ public class NaiveBayes {
 
         // read from a file assuming a list of attributes and a class name last on each line
         DocGen dg = DocGen.getInstance();
-        //NaiveBayes nb = new NaiveBayes("/home/apease/IPsoft/NB/NBdata.txt");
-        //NaiveBayes nb = new NaiveBayes("/home/apease/IPsoft/NB/house-votes-84.data");
+        //NaiveBayes nb = new NaiveBayes(System.getProperty("user.home") + "/IPsoft/NB/NBdata.txt");
+        //NaiveBayes nb = new NaiveBayes(System.getProperty("user.home") + "/IPsoft/NB/house-votes-84.data");
         NaiveBayes nb = null;
         ArrayList<String> values = null;
         if (args.length >= 1) {
@@ -421,7 +421,7 @@ public class NaiveBayes {
             }
         }
         else {
-            nb = new NaiveBayes("/home/apease/IPsoft/NB/pima-indians-diabetes.data");
+            nb = new NaiveBayes(System.getProperty("user.home") + "/IPsoft/NB/pima-indians-diabetes.data");
             values = Lists.newArrayList("4","111","72","47","207","37.1","1.390","56");
             nb.initialize();
             System.out.println("main(): most likely class: " + nb.classify(values));

--- a/src/main/java/com/articulate/nlp/SUMOOverlap.java
+++ b/src/main/java/com/articulate/nlp/SUMOOverlap.java
@@ -68,7 +68,7 @@ public class SUMOOverlap {
         TFIDF cb = null;
         SynsetOverlap so = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             so = new SynsetOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/SUMOOverlap.java
+++ b/src/main/java/com/articulate/nlp/SUMOOverlap.java
@@ -68,7 +68,7 @@ public class SUMOOverlap {
         TFIDF cb = null;
         SynsetOverlap so = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             so = new SynsetOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/SynsetOverlap.java
+++ b/src/main/java/com/articulate/nlp/SynsetOverlap.java
@@ -68,7 +68,7 @@ public class SynsetOverlap {
         TFIDF cb = null;
         SynsetOverlap so = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             so = new SynsetOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/SynsetOverlap.java
+++ b/src/main/java/com/articulate/nlp/SynsetOverlap.java
@@ -68,7 +68,7 @@ public class SynsetOverlap {
         TFIDF cb = null;
         SynsetOverlap so = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             so = new SynsetOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/TokenOverlap.java
+++ b/src/main/java/com/articulate/nlp/TokenOverlap.java
@@ -53,7 +53,7 @@ public class TokenOverlap {
         TFIDF cb = null;
         TokenOverlap to = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/TokenOverlap.java
+++ b/src/main/java/com/articulate/nlp/TokenOverlap.java
@@ -53,7 +53,7 @@ public class TokenOverlap {
         TFIDF cb = null;
         TokenOverlap to = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
         }
         catch (IOException ioe) {

--- a/src/main/java/com/articulate/nlp/WNsim.java
+++ b/src/main/java/com/articulate/nlp/WNsim.java
@@ -568,15 +568,15 @@ public class WNsim {
     public static void test() {
 
         //System.out.println("INFO in WNsim.test() ");
-        HashMap<String,HashMap<String,Float>> hm = readTestFile("/home/apease/WordSim/scws.csv",
+        HashMap<String,HashMap<String,Float>> hm = readTestFile(System.getProperty("user.home") + "/WordSim/scws.csv",
                 "([^\\t]+)\\t([^\\t]+)\\t(.*)",false);
-        //HashMap<String,HashMap<String,Float>> hm = readTestFile("/home/apease/WordSim/wordsim353/combined-noHead.tab",
+        //HashMap<String,HashMap<String,Float>> hm = readTestFile(System.getProperty("user.home") + "/WordSim/wordsim353/combined-noHead.tab",
         //        "([^\\t]+)\\t([^\\t]+)\\t(.*)",false);
-        //HashMap<String,HashMap<String,Float>> hm = readTestFile("/home/apease/WordSim/rw/rw.txt",
+        //HashMap<String,HashMap<String,Float>> hm = readTestFile(System.getProperty("user.home") + "/WordSim/rw/rw.txt",
         //        "([^\\t]+)\\t([^\\t]+)\\t([^\\t]+).*",false);
-        //HashMap<String,HashMap<String,Float>> hm = readTestFile("/home/apease/WordSim/Resnik3.txt",
+        //HashMap<String,HashMap<String,Float>> hm = readTestFile(System.getProperty("user.home") + "/WordSim/Resnik3.txt",
         //        "([^ ]+) ([^ ]+) (.*)",false);
-        //HashMap<String,HashMap<String,Float>> hm = readTestFile("/home/apease/WordSim/MEN/MEN_dataset_lemma_form_full",
+        //HashMap<String,HashMap<String,Float>> hm = readTestFile(System.getProperty("user.home") + "/WordSim/MEN/MEN_dataset_lemma_form_full",
         //        "([^ ]+) ([^ ]+) (.*)",true);
         HashMap<String,HashMap<String,Float>> hm2 = new HashMap<>();
         HashMap<String,Float> results1 = new HashMap<>();

--- a/src/main/java/com/articulate/nlp/corpora/Coinco.java
+++ b/src/main/java/com/articulate/nlp/corpora/Coinco.java
@@ -146,6 +146,6 @@ public class Coinco {
     public static void main(String[] args) {
 
         Coinco c = new Coinco();
-        c.parse("/home/apease/IPsoft/corpora/coinco/coinco.xml");
+        c.parse(System.getProperty("user.home") + "/IPsoft/corpora/coinco/coinco.xml");
     }
 }

--- a/src/main/java/com/articulate/nlp/corpora/SemEval2007.java
+++ b/src/main/java/com/articulate/nlp/corpora/SemEval2007.java
@@ -37,9 +37,9 @@ public class SemEval2007 {
      */
     public static void load() {
 
-        WordNet.wn.readSenseIndex("/home/apease/corpora/WordNet-2.0/dict/index.sense");
+        WordNet.wn.readSenseIndex(System.getProperty("user.home") + "/corpora/WordNet-2.0/dict/index.sense");
         try {
-            WordNetUtilities.updateWNversionReading("/home/apease/corpora/mappings-upc-2007/mapping-30-21/", "30-21");
+            WordNetUtilities.updateWNversionReading(System.getProperty("user.home") + "/corpora/mappings-upc-2007/mapping-30-21/", "30-21");
         }
         catch (IOException ioe) {
             System.out.println("Error in XtendedWN.main()" + ioe.getMessage());

--- a/src/main/java/com/articulate/nlp/corpora/ShuZiInsQA.java
+++ b/src/main/java/com/articulate/nlp/corpora/ShuZiInsQA.java
@@ -95,7 +95,7 @@ public class ShuZiInsQA {
      */
     private void readVocab() {
 
-        List<String> lines = readLines("/home/apease/IPsoft/insuranceQA-master/vocabulary-mod");
+        List<String> lines = readLines(System.getProperty("user.home") + "/IPsoft/insuranceQA-master/vocabulary-mod");
         for (String l : lines) {
             String[] elements = l.split("\\t");
             if (elements.length == 2) {
@@ -154,7 +154,7 @@ public class ShuZiInsQA {
 
         TFIDF cb = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
@@ -163,7 +163,7 @@ public class ShuZiInsQA {
         answers.add(""); // make 0th element blank
         answerNgrams.add(new HashMap<>());
         int linenum = 1;
-        List<String> lines = readLines("/home/apease/IPsoft/insuranceQA-master/answers.label.token_idx");
+        List<String> lines = readLines(System.getProperty("user.home") + "/IPsoft/insuranceQA-master/answers.label.token_idx");
         for (String l : lines) {
             String[] elements = l.split("\\t");
             String answerID = elements[0];
@@ -196,7 +196,7 @@ public class ShuZiInsQA {
      */
     private void readTrainingQuestions() {
 
-        List<String> lines = readLines("/home/apease/IPsoft/insuranceQA-master/question.train.token_idx.label");
+        List<String> lines = readLines(System.getProperty("user.home") + "/IPsoft/insuranceQA-master/question.train.token_idx.label");
         for (String l : lines) {
             String[] elements = l.split("\\t");
             String answer = elements[1];
@@ -232,13 +232,13 @@ public class ShuZiInsQA {
         List<Dev> result = new ArrayList<>();
         TFIDF cb = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
             ioe.printStackTrace();
         }
-        List<String> lines = readLines("/home/apease/IPsoft/insuranceQA-master/question.dev.label.token_idx.pool");
+        List<String> lines = readLines(System.getProperty("user.home") + "/IPsoft/insuranceQA-master/question.dev.label.token_idx.pool");
         int count = 0;
         for (String l : lines) {
             if (StringUtil.emptyString(l)) continue;
@@ -287,7 +287,7 @@ public class ShuZiInsQA {
 
         TFIDF cb = null;
         try {
-            cb = new TFIDF("/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
@@ -336,7 +336,7 @@ public class ShuZiInsQA {
      */
     private ArrayList<Dev> readTestQuestionOneFile() {
 
-        ArrayList<Dev> test = readTestQuestionFile("/home/apease/IPsoft/insuranceQA-master/question.dev.label.token_idx.pool");
+        ArrayList<Dev> test = readTestQuestionFile(System.getProperty("user.home") + "/IPsoft/insuranceQA-master/question.dev.label.token_idx.pool");
         return test;
     }
 
@@ -915,7 +915,7 @@ public class ShuZiInsQA {
             sziq.readVocab();
             sziq.readAnswers();
             a.addAll(sziq.answers);
-            cb = new TFIDF(a,"/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(a,System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
 
         }
@@ -949,7 +949,7 @@ public class ShuZiInsQA {
         try {
             List<String> a = new ArrayList<>();
             a.addAll(answers);
-            cb = new TFIDF(a,"/home/apease/Sigma/KBs/stopwords.txt");
+            cb = new TFIDF(a,System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
             ng = new NGramOverlap(cb);
             so = new SynsetOverlap(cb);

--- a/src/main/java/com/articulate/nlp/corpora/ShuZiInsQA.java
+++ b/src/main/java/com/articulate/nlp/corpora/ShuZiInsQA.java
@@ -154,7 +154,7 @@ public class ShuZiInsQA {
 
         TFIDF cb = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
@@ -232,7 +232,7 @@ public class ShuZiInsQA {
         List<Dev> result = new ArrayList<>();
         TFIDF cb = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
@@ -287,7 +287,7 @@ public class ShuZiInsQA {
 
         TFIDF cb = null;
         try {
-            cb = new TFIDF(System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
         }
         catch (IOException ioe) {
             System.out.println("Error in ShuZiInsQA.readAnswers()");
@@ -915,7 +915,7 @@ public class ShuZiInsQA {
             sziq.readVocab();
             sziq.readAnswers();
             a.addAll(sziq.answers);
-            cb = new TFIDF(a,System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(a,System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
 
         }
@@ -949,7 +949,7 @@ public class ShuZiInsQA {
         try {
             List<String> a = new ArrayList<>();
             a.addAll(answers);
-            cb = new TFIDF(a,System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings/stopwords.txt");
+            cb = new TFIDF(a,System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings/stopwords.txt");
             to = new TokenOverlap(cb);
             ng = new NGramOverlap(cb);
             so = new SynsetOverlap(cb);

--- a/src/main/java/com/articulate/nlp/corpora/TimeBank.java
+++ b/src/main/java/com/articulate/nlp/corpora/TimeBank.java
@@ -899,10 +899,10 @@ public class TimeBank {
     public static void testText() {
 
         anchorDate = "2015-06-01";
-        //String filename = "/home/apease/Infosys/SampleDocuments/IBEW.txt";
-       // String filename = "/home/apease/Infosys/SampleDocuments/BofAonlineBankingAgreement.txt";
-        //String filename = "/home/apease/corpora/timebank_1_2/data/timeml/ABC19980108.1830.0711.tml";
-        String filename = "/home/apease/Infosys/SampleDocuments/accountingPnP-Wegner.txt";
+        //String filename = System.getProperty("user.home") + "/Infosys/SampleDocuments/IBEW.txt";
+       // String filename = System.getProperty("user.home") + "/Infosys/SampleDocuments/BofAonlineBankingAgreement.txt";
+        //String filename = System.getProperty("user.home") + "/corpora/timebank_1_2/data/timeml/ABC19980108.1830.0711.tml";
+        String filename = System.getProperty("user.home") + "/Infosys/SampleDocuments/accountingPnP-Wegner.txt";
 
         init();
         //processText(filename);
@@ -958,7 +958,7 @@ public class TimeBank {
         }
 
         else if (args[0].equals("-c")) {
-            testTimeBankNew("/home/apease/corpora/timebank_1_2/data/extra");
+            testTimeBankNew(System.getProperty("user.home") + "/corpora/timebank_1_2/data/extra");
         }
         else if (args[0].equals("-u")) {
             testTimeBankUnit();
@@ -982,7 +982,7 @@ public class TimeBank {
             System.out.println("anchor date: " + anchorDate);
             interactive();
         }
-        //testTimeBankNew("/home/apease/corpora/timebank_1_2/test");
+        //testTimeBankNew(System.getProperty("user.home") + "/corpora/timebank_1_2/test");
         //testText();
         //testParseDateString();
     }

--- a/src/main/java/com/articulate/nlp/semRewrite/Interpreter.java
+++ b/src/main/java/com/articulate/nlp/semRewrite/Interpreter.java
@@ -1589,7 +1589,7 @@ public class Interpreter {
     public void loadRules(String f) {
 
         if (f.indexOf(File.separator.toString(),2) < 0)
-            f = "/home/apease/workspace/sumo/WordNetMappings" + File.separator + f;
+            f = System.getProperty("user.home") + "/workspace/sumo/WordNetMappings" + File.separator + f;
         try {
             fname = f;
             RuleSet rsin = RuleSet.readFile(f);
@@ -1610,7 +1610,7 @@ public class Interpreter {
 
        // String filename = KBmanager.getMgr().getPref("kbDir") + File.separator +
                // "WordNetMappings" + File.separator + "SemRewrite.txt";
-        String filename = "/home/apease/workspace/sumo/WordNetMappings" + File.separator + "SemRewrite.txt";
+        String filename = System.getProperty("user.home") + "/workspace/sumo/WordNetMappings" + File.separator + "SemRewrite.txt";
         String pref = KBmanager.getMgr().getPref("SemRewrite");
         if (!Strings.isNullOrEmpty(pref))
             filename = pref;

--- a/src/main/java/com/articulate/nlp/semRewrite/RewriteRuleUtil.java
+++ b/src/main/java/com/articulate/nlp/semRewrite/RewriteRuleUtil.java
@@ -101,7 +101,7 @@ public final class RewriteRuleUtil extends RuleSet {
         if (!Strings.isNullOrEmpty(pref))
             f = pref;
         if (f.indexOf(File.separator.toString(), 2) < 0)
-            f = System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings" + f;
+            f = System.getenv("SIGMA_HOME") + "/KBs/WordNetMappings" + f;
         try {
             RuleSet rsin = RuleSet.readFile(f);
             rs = canon(rsin);

--- a/src/main/java/com/articulate/nlp/semRewrite/RewriteRuleUtil.java
+++ b/src/main/java/com/articulate/nlp/semRewrite/RewriteRuleUtil.java
@@ -101,7 +101,7 @@ public final class RewriteRuleUtil extends RuleSet {
         if (!Strings.isNullOrEmpty(pref))
             f = pref;
         if (f.indexOf(File.separator.toString(), 2) < 0)
-            f = "/home/apease/SourceForge/KBs/WordNetMappings" + f;
+            f = System.getProperty("user.home") + "/.sigmakee/KBs/WordNetMappings" + f;
         try {
             RuleSet rsin = RuleSet.readFile(f);
             rs = canon(rsin);

--- a/src/main/java/com/articulate/nlp/semRewrite/RuleSet.java
+++ b/src/main/java/com/articulate/nlp/semRewrite/RuleSet.java
@@ -123,7 +123,7 @@ public class RuleSet {
      */
     public static void testReadRuleSet() {
     
-        String filename = "/home/apease/IPsoft/SemRewrite.txt";
+        String filename = System.getProperty("user.home") + "/IPsoft/SemRewrite.txt";
         try {
             RuleSet rs = RuleSet.readFile(filename);
         }

--- a/src/main/java/com/articulate/nlp/semRewrite/substitutor/MUC.java
+++ b/src/main/java/com/articulate/nlp/semRewrite/substitutor/MUC.java
@@ -218,7 +218,7 @@ public class MUC {
         //props.setProperty("annotators", "tokenize, ssplit, pos, lemma, ner, parse, dcoref");
         props.setProperty("annotators", "tokenize, ssplit, pos, lemma, ner, entitymentions, parse, depparse, hcoref");
         props.setProperty("tokenize.options", "ptb3Escaping=false");
-        //String[] configFileProp = {"-props","/home/apease/Programs/stanford-corenlp-full-2015-04-20/CoreNLP/build/resources/main/edu/stanford/com.articulate.nlp/hcoref/properties/coref-default-dep.properties"};
+        //String[] configFileProp = {"-props",System.getProperty("user.home") + "/Programs/stanford-corenlp-full-2015-12-09/CoreNLP/build/resources/main/edu/stanford/com.articulate.nlp/hcoref/properties/coref-default-dep.properties"};
         String[] configFileProp = {"-props",System.getenv("COREF")};
         props.putAll(StringUtils.argsToPropertiesWithResolve(configFileProp));
         System.out.println("MUC.toCoref(): before initialized pipeline");
@@ -995,11 +995,11 @@ public class MUC {
      */
     public void testMUC() {
 
-        //List<String> lines = cleanSGML("/home/apease/IPsoft/corpora/muc6/data/keys/formal-tst.CO.key.cleanup.09jul96");
-        //List<String> lines = getDocuments("/home/apease/IPsoft/corpora/muc6/data/keys/formal-tst.CO.key.cleanup.09jul96");
+        //List<String> lines = cleanSGML(System.getProperty("user.home") + "/IPsoft/corpora/muc6/data/keys/formal-tst.CO.key.cleanup.09jul96");
+        //List<String> lines = getDocuments(System.getProperty("user.home") + "/IPsoft/corpora/muc6/data/keys/formal-tst.CO.key.cleanup.09jul96");
         List<String> lines = getDocuments(System.getenv("MUCCORPUS") + File.separator + "formal-tst.CO.key.cleanup.09jul96");
-        //List<String> lines = getDocuments("/home/apease/IPsoft/corpora/muc6/data/keys/Wash.txt");
-        //List<String> lines = getDocuments("/home/apease/IPsoft/corpora/muc6/data/keys/891101-0056.co.v0.sgm" + "");
+        //List<String> lines = getDocuments(System.getProperty("user.home") + "/IPsoft/corpora/muc6/data/keys/Wash.txt");
+        //List<String> lines = getDocuments(System.getProperty("user.home") + "/IPsoft/corpora/muc6/data/keys/891101-0056.co.v0.sgm" + "");
         for (String s : lines) {
             String cleanedInput = s.replaceAll("<COREF[^>]+>", "");
             cleanedInput = cleanedInput.replace("</COREF>","");


### PR DESCRIPTION
These commits replace all references to `/home/apeace` with `System.getProperty("user.home")`, all references to `KBs` with `System.getenv("SIGMA_HOME") + "/KBs"`, and all hardcoded paths to the java binary with `System.getProperty("java.home") + "/java"`.  Note that `java.home` returns the currently running jvm's directory, so its use is still consistent with `java` not being in the system path or having multiple java binaries installed.

In addition, these commits update paths for `stopwords.txt` to its current location in `WordNetMappings` as well as the path for Stanford Core NLP to the currently installed (as per the README) `stanford-corenlp-full-2015-12-09`.

There is still an uncomfortable amount of hardcoding present in the referenced paths.  In the future, it would be better to expect all required files to either be located in `SIGMA_HOME` or have their paths specified by `config.xml`.  That sigmanlp has been working for others with the extent of hardcoded paths changed by this commit suggests that most (all?) of the changes made are in dead code.