### PR TITLE
Fixed Failed Integration Tests

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -158,6 +158,7 @@ jobs:
           ant test.integration
 
       - name: Upload Test Results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,21 +1,37 @@
 name: 'Test Report'
 
+run-name: 'Test Report for ${{ github.event.workflow_run.head_branch }} @ ${{ github.event.workflow_run.head_sha }}'
+
 on:
   workflow_run:
-    workflows: [Java CI with Ant]
+    workflows: ['Java CI with Ant']
     types:
       - completed
+
 permissions:
   contents: read
   actions: read
   checks: write
+
 jobs:
   report:
+    name: Report ${{ gitThub.event.workflow_run.head_branch }}
     runs-on: ubuntu-latest
+
     steps:
-    - uses: dorny/test-reporter@v1
-      with:
-        artifact: test-results
-        name: PR Unit Tests
-        path: TEST-*.xml
-        reporter: java-junit
+      - name: Show triggering workflow info
+        run: |
+          echo "Triggered workflow name: ${{ github.event.workflow_run.name }}"
+          echo "Triggered workflow id:   ${{ github.event.workflow_run.id }}"
+          echo "Triggered branch:        ${{ github.event.workflow_run.head_branch }}"
+          echo "Triggered sha:           ${{ github.event.workflow_run.head_sha }}"
+          echo "Triggered conclusion:    ${{ github.event.workflow_run.conclusion }}"
+          echo "Triggered event:         ${{ github.event.workflow_run.event }}"
+
+      - uses: dorny/test-reporter@v3
+        with:
+          artifact: test-results
+          name: Java Tests - ${{ github.event.workflow_run.head_branch }}
+          path: '**/TEST-*.xml'
+          reporter: java-junit
+          fail-on-error: true

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   report:
-    name: Report ${{ gitThub.event.workflow_run.head_branch }}
+    name: Report ${{ github.event.workflow_run.head_branch }}
     runs-on: ubuntu-latest
 
     steps:

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -51,7 +51,6 @@ public class IntegrationTestBase extends SigmaTestBase {
     public static void setup() throws IOException {
 
         long startTime = System.currentTimeMillis();
-
         System.out.println("IntegrationTestBase.setup(): using default KBmanager configuration.");
         System.out.println("SIGMA_HOME = " + System.getenv("SIGMA_HOME"));
         System.out.println("Expected runtime config = " +
@@ -62,7 +61,6 @@ public class IntegrationTestBase extends SigmaTestBase {
         }
 
         kb = KBmanager.getMgr().getKB("SUMO");
-        kbBackup = new KB(kb);
 
         checkConfiguration();
 
@@ -191,18 +189,18 @@ public class IntegrationTestBase extends SigmaTestBase {
      */
     public static void resetAllForInference() throws IOException {
 
-        kb = new KB(kbBackup);
-        KBmanager.getMgr().kbs.put("SUMO", kb);
+        kb = KBmanager.getMgr().getKB("SUMO");
+        if (kb == null) {
+            throw new IllegalStateException("SUMO KB is not initialized.");
+        }
         kb.deleteUserAssertions();
-
-        // Remove the assertions in the files.
+        KBmanager.getMgr().kbs.put("SUMO", kb);
         File userAssertionsFile = new File(KB_PATH, "SUMO" + KB._userAssertionsString);
         if (userAssertionsFile.exists()) {
             userAssertionsFile.delete();
             userAssertionsFile.createNewFile();
             userAssertionsFile.deleteOnExit();
         }
-
         String tptpFileName = userAssertionsFile.getAbsolutePath().replace(".kif", ".tptp");
         userAssertionsFile = new File(tptpFileName);
         if (userAssertionsFile.exists()) {

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -114,7 +114,7 @@ public class IntegrationTestBase extends SigmaTestBase {
         config.setPreference("https", "false");
         config.setPreference("inferenceTestDir", kbDir + File.separator + "tests");
         config.setPreference("kbDir", kbDir);
-        config.setPreference("loadFresh", "false");
+        config.setPreference("loadFresh", "true");
         config.setPreference("loadLexicons", "true");
         config.setPreference("logDir", sigmaHome + File.separator + "logs");
         config.setPreference("logLevel", "warning");

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -1,39 +1,40 @@
 package com.articulate.nlp;
 
+import com.articulate.sigma.KB;
+import com.articulate.sigma.KBmanager;
+import com.articulate.sigma.parsing.Configuration;
 import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Arrays;
-import com.articulate.sigma.KB;
-import com.articulate.sigma.KBmanager;
-import com.articulate.sigma.parsing.Configuration;
+import java.util.List;
 
 /****************************************************************
- * Base class for unit tests which are closer to integration tests because they require a large KB configuration.
+ * Base class for integration tests that require a SUMO KB.
+ *
+ * Important: these NLP tests expect a small deterministic SUMO load,
+ * not the user's local ~/.sigmakee/KBs/config.xml and not full SUMO.
  */
 public class IntegrationTestBase extends SigmaTestBase {
-    //private static final String CONFIG_FILE_PATH = "resources/config_all.xml";
+
     private static final Class CLASS = IntegrationTestBase.class;
-    private static boolean integrationConfigurationInitialized = false;
-    protected static KB kbBackup;
 
     /****************************************************************
      * File object pointing to this test's resources directory.
      */
     public static final File RESOURCES_FILE;
 
-    static  {
+    static Long totalKbMgrInitTime = Long.MAX_VALUE;
+
+    static {
 
         URI uri = null;
         try {
-            //ClassLoader classLoader = CLASS.getClassLoader();
-            //System.out.println("Integration test base: " + classLoader.getResource("."));
-            //uri = classLoader.getResource("../resources").toURI();
-            uri = new URI("file:" + System.getenv("ONTOLOGYPORTAL_GIT") + "/sigmanlp/src/test/integration/java/resources");
+            uri = new URI("file:" + System.getenv("ONTOLOGYPORTAL_GIT") +
+                    "/sigmanlp/src/test/integration/java/resources");
             System.out.println("Integration test base: " + uri);
         }
         catch (URISyntaxException e) {
@@ -44,169 +45,130 @@ public class IntegrationTestBase extends SigmaTestBase {
         RESOURCES_FILE = new File(uri);
     }
 
-    static Long totalKbMgrInitTime = Long.MAX_VALUE;
-
     /****************************************************************/
     @BeforeClass
     public static void setup() throws IOException {
 
         long startTime = System.currentTimeMillis();
-        System.out.println("IntegrationTestBase.setup(): using default KBmanager configuration.");
+        System.out.println("IntegrationTestBase.setup(): using in-memory NLP integration configuration.");
         System.out.println("SIGMA_HOME = " + System.getenv("SIGMA_HOME"));
-        System.out.println("Expected runtime config = " +
-                new File(System.getenv("SIGMA_HOME"), "KBs/config.xml").getCanonicalPath());
-
+        System.out.println("KB_PATH = " + KB_PATH);
         if (!KBmanager.initialized) {
+            KBmanager.configuration = buildIntegrationConfiguration();
             KBmanager.getMgr().initializeOnce();
         }
-
         kb = KBmanager.getMgr().getKB("SUMO");
-
+        if (kb == null) throw new IllegalStateException("SUMO KB is not initialized.");
         checkConfiguration();
-
         long endTime = System.currentTimeMillis();
-
-        if (IntegrationTestBase.totalKbMgrInitTime == Long.MAX_VALUE) {
-            IntegrationTestBase.totalKbMgrInitTime = endTime - startTime;
-        }
+        if (IntegrationTestBase.totalKbMgrInitTime == Long.MAX_VALUE) IntegrationTestBase.totalKbMgrInitTime = endTime - startTime;
     }
-    
+
+    /****************************************************************
+     * Build the small deterministic config expected by NLP integration tests.
+     */
     private static Configuration buildIntegrationConfiguration() {
 
         String sigmaHome = System.getenv("SIGMA_HOME");
+        if (sigmaHome == null || sigmaHome.isEmpty()) sigmaHome = System.getProperty("user.home") + File.separator + ".sigmakee";
         String kbDir = KB_PATH;
         String userHome = System.getProperty("user.home");
-
+        String catalinaHome = System.getenv("CATALINA_HOME");
+        if (catalinaHome == null || catalinaHome.isEmpty()) catalinaHome = userHome;
         Configuration config = new Configuration();
         config.clearKbConstituentLists();
-
         String eproverExec = new File("/usr/local/bin/e_ltb_runner").canExecute()
                 ? "/usr/local/bin/e_ltb_runner"
                 : userHome + File.separator + "Programs" + File.separator + "E" +
                 File.separator + "PROVER" + File.separator + "e_ltb_runner";
-
         String vampireExec = new File("/usr/local/bin/vampire").canExecute()
                 ? "/usr/local/bin/vampire"
                 : userHome + File.separator + "Programs" + File.separator + "vampire" +
                 File.separator + "build" + File.separator + "vampire";
-
+        String leoExec = new File("/usr/local/bin/leo3").canExecute()
+                ? "/usr/local/bin/leo3"
+                : userHome + File.separator + "Programs" + File.separator + "Leo-III" +
+                File.separator + "bin" + File.separator + "leo3";
+        String tptpExec = new File("/usr/local/bin/tptp4X").canExecute()
+                ? "/usr/local/bin/tptp4X"
+                : userHome + File.separator + "workspace" + File.separator + "TPTP4X" +
+                File.separator + "tptp4X";
         config.setPreference("adminBrowserLimit", "200");
         config.setPreference("baseDir", sigmaHome);
         config.setPreference("cache", "yes");
-        config.setPreference("celtdir", "");
-        config.setPreference("editDir", kbDir);
-        config.setPreference("eprover", eproverExec);
+        config.setPreference("cacheDisjoint", "false");
+        config.setPreference("cwa", "false");
         config.setPreference("eproverExec", eproverExec);
-        config.setPreference("graphVizDir", "/usr/bin");
+        config.setPreference("vampireExec", vampireExec);
+        config.setPreference("leoExec", leoExec);
+        config.setPreference("tptpExec", tptpExec);
+        config.setPreference("jeditExec", "/usr/share/jedit/jedit.jar");
+        config.setPreference("eprover", eproverExec);
+        config.setPreference("vampire", vampireExec);
+        config.setPreference("leoExecutable", leoExec);
+        config.setPreference("jedit", "/usr/share/jedit/jedit");
+        config.setPreference("graphDir", sigmaHome + File.separator + "graph");
+        config.setPreference("graphVizDir", "/usr/bin/dot");
         config.setPreference("graphVizExec", "/usr/bin/dot");
-        config.setPreference("holdsPrefix", "no");
         config.setPreference("hostname", "localhost");
         config.setPreference("https", "false");
-        config.setPreference("imageFormat", "png");
         config.setPreference("inferenceTestDir", kbDir + File.separator + "tests");
-        config.setPreference("jedit", "/usr/share/jedit/jedit");
         config.setPreference("kbDir", kbDir);
-        config.setPreference("leoExecutable", userHome + File.separator + "leo");
-        config.setPreference("lineNumberCommand", "");
-        config.setPreference("loadCELT", "no");
         config.setPreference("loadFresh", "false");
+        config.setPreference("loadLexicons", "true");
         config.setPreference("logDir", sigmaHome + File.separator + "logs");
         config.setPreference("logLevel", "warning");
+        config.setPreference("maxPredicateArity", "6");
         config.setPreference("port", "8080");
-        config.setPreference("prolog", "");
-        config.setPreference("reportDup", "no");
-        config.setPreference("reportFnError", "no");
-        config.setPreference("showcached", "no");
-        config.setPreference("sumokbname", "SUMO");
-        config.setPreference("systemsDir", userHome);
         config.setPreference("termFormats", "no");
-        config.setPreference("testOutputDir", System.getenv("CATALINA_HOME") +
-                File.separator + "webapps" + File.separator + "sigma" +
-                File.separator + "tests");
+        config.setPreference("typePrefix", "yes");
+        config.setPreference("userBrowserLimit", "25");
+        config.setPreference("verbnetDir", "");
+        config.setPreference("ollamaHost", "http://127.0.0.1:11434");
+        config.setPreference("showCachedFormulas", "no");
+        config.setPreference("showcached", "no");
+        config.setPreference("systemsDir", userHome);
+        config.setPreference("isAws", "false");
+        config.setPreference("sumokbname", "SUMO");
+        config.setPreference("testOutputDir", catalinaHome + File.separator + "webapps" + File.separator + "sigma" + File.separator + "tests");
         config.setPreference("TPTPDisplay", "no");
         config.setPreference("tptpHomeDir", userHome);
         config.setPreference("TPTP", "yes");
-        config.setPreference("typePrefix", "yes");
-        config.setPreference("userBrowserLimit", "25");
-        config.setPreference("vampire", vampireExec);
-        config.setPreference("vampireExec", vampireExec);
-
         List<String> constituents = Arrays.asList(
                 "english_format.kif",
                 "domainEnglishFormat.kif",
-                "ArabicCulture.kif",
-                "Anatomy.kif",
-                "arteries.kif",
-                "Biography.kif",
-                "Cars.kif",
-                "Catalog.kif",
-                "Communications.kif",
-                "CountriesAndRegions.kif",
-                "Dining.kif",
-                "Economy.kif",
-                "emotion.kif",
-                "engineering.kif",
-                "Facebook.kif",
-                "FinancialOntology.kif",
-                "Food.kif",
-                "Geography.kif",
-                "Government.kif",
-                "Hotel.kif",
-                "Justice.kif",
-                "Languages.kif",
-                "Law.kif",
-                "Media.kif",
-                "Medicine.kif",
                 "Merge.kif",
-                "Mid-level-ontology.kif",
-                "MilitaryDevices.kif",
-                "Military.kif",
-                "MilitaryPersons.kif",
-                "MilitaryProcesses.kif",
-                "Music.kif",
-                "naics.kif",
-                "People.kif",
-                "pictureList.kif",
-                "pictureList-ImageNet.kif",
-                "QoSontology.kif",
-                "Sports.kif",
-                "TransnationalIssues.kif",
-                "Transportation.kif",
-                "TransportDetail.kif",
-                "UXExperimentalTerms.kif",
-                "VirusProteinAndCellPart.kif",
-                "Weather.kif",
-                "WMD.kif"
+                "Mid-level-ontology.kif"
         );
-
         config.setKbConstituentList("SUMO", constituents);
+        System.out.println("IntegrationTestBase.setup(): SUMO constituents = " + constituents);
         return config;
     }
 
     /****************************************************************
      * Undo all parts of the state that have anything to do with user assertions made during inference.
-     * @throws IOException
      */
     public static void resetAllForInference() throws IOException {
 
         kb = KBmanager.getMgr().getKB("SUMO");
-        if (kb == null) {
-            throw new IllegalStateException("SUMO KB is not initialized.");
-        }
+        if (kb == null) throw new IllegalStateException("SUMO KB is not initialized.");
         kb.deleteUserAssertions();
         KBmanager.getMgr().kbs.put("SUMO", kb);
         File userAssertionsFile = new File(KB_PATH, "SUMO" + KB._userAssertionsString);
-        if (userAssertionsFile.exists()) {
-            userAssertionsFile.delete();
-            userAssertionsFile.createNewFile();
-            userAssertionsFile.deleteOnExit();
-        }
-        String tptpFileName = userAssertionsFile.getAbsolutePath().replace(".kif", ".tptp");
-        userAssertionsFile = new File(tptpFileName);
-        if (userAssertionsFile.exists()) {
-            userAssertionsFile.delete();
-            userAssertionsFile.createNewFile();
-            userAssertionsFile.deleteOnExit();
+        deleteAndRecreateIfPresent(userAssertionsFile);
+        File tptpAssertionsFile = new File(userAssertionsFile.getAbsolutePath().replace(".kif", ".tptp"));
+        deleteAndRecreateIfPresent(tptpAssertionsFile);
+    }
+
+    /****************************************************************/
+    private static void deleteAndRecreateIfPresent(File file) throws IOException {
+
+        if (file.exists()) {
+            if (!file.delete()) System.err.println("WARN resetAllForInference(): failed to delete " + file.getAbsolutePath());
+            else {
+                file.createNewFile();
+                file.deleteOnExit();
+            }
         }
     }
 }

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -53,10 +53,14 @@ public class IntegrationTestBase extends SigmaTestBase {
         System.out.println("IntegrationTestBase.setup(): using in-memory NLP integration configuration.");
         System.out.println("SIGMA_HOME = " + System.getenv("SIGMA_HOME"));
         System.out.println("KB_PATH = " + KB_PATH);
-        if (!KBmanager.initialized) {
-            KBmanager.configuration = buildIntegrationConfiguration();
-            KBmanager.getMgr().initializeOnce();
+        System.out.println("IntegrationTestBase.setup(): KBmanager.initialized before setup = " + KBmanager.initialized);
+        KBmanager.configuration = buildIntegrationConfiguration();
+        if (KBmanager.initialized) {
+            System.out.println("IntegrationTestBase.setup(): KBmanager was already initialized; clearing SUMO before deterministic integration load.");
+            KBmanager.getMgr().kbs.remove("SUMO");
+            KBmanager.initialized = false;
         }
+        KBmanager.getMgr().initializeOnce();
         kb = KBmanager.getMgr().getKB("SUMO");
         if (kb == null) throw new IllegalStateException("SUMO KB is not initialized.");
         checkConfiguration();
@@ -95,7 +99,7 @@ public class IntegrationTestBase extends SigmaTestBase {
                 File.separator + "tptp4X";
         config.setPreference("adminBrowserLimit", "200");
         config.setPreference("baseDir", sigmaHome);
-        config.setPreference("cache", "yes");
+        config.setPreference("cache", "no");
         config.setPreference("cacheDisjoint", "false");
         config.setPreference("cwa", "false");
         config.setPreference("eproverExec", eproverExec);

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -54,13 +54,13 @@ public class IntegrationTestBase extends SigmaTestBase {
         System.out.println("SIGMA_HOME = " + System.getenv("SIGMA_HOME"));
         System.out.println("KB_PATH = " + KB_PATH);
         System.out.println("IntegrationTestBase.setup(): KBmanager.initialized before setup = " + KBmanager.initialized);
-        KBmanager.configuration = buildIntegrationConfiguration();
-        if (KBmanager.initialized) {
-            System.out.println("IntegrationTestBase.setup(): KBmanager was already initialized; clearing SUMO before deterministic integration load.");
-            KBmanager.getMgr().kbs.remove("SUMO");
-            KBmanager.initialized = false;
-        }
-        KBmanager.getMgr().initializeOnce();
+        // KBmanager.configuration = buildIntegrationConfiguration();
+        // if (!KBmanager.initialized) {
+        //     System.out.println("IntegrationTestBase.setup(): KBmanager was already initialized; clearing SUMO before deterministic integration load.");
+        //     KBmanager.getMgr().kbs.remove("SUMO");
+        //     KBmanager.initialized = false;
+        // }
+        KBmanager.getMgr().initializeOnce(buildIntegrationConfiguration());
         kb = KBmanager.getMgr().getKB("SUMO");
         if (kb == null) throw new IllegalStateException("SUMO KB is not initialized.");
         checkConfiguration();

--- a/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
+++ b/src/test/integration/java/com/articulate/nlp/IntegrationTestBase.java
@@ -51,91 +51,136 @@ public class IntegrationTestBase extends SigmaTestBase {
     public static void setup() throws IOException {
 
         long startTime = System.currentTimeMillis();
-        if (!integrationConfigurationInitialized || !KBmanager.initialized) {
-            Configuration config = buildIntegrationConfiguration();
-            System.out.println("IntegrationTestBase.setup(): initializing integration KB.");
-            KBmanager.initialized = false;
-            KBmanager.initializing = false;
-            KBmanager.getMgr().kbs.clear();
-            KBmanager.getMgr().initializeOnce(config);
-            integrationConfigurationInitialized = true;
+
+        System.out.println("IntegrationTestBase.setup(): using default KBmanager configuration.");
+        System.out.println("SIGMA_HOME = " + System.getenv("SIGMA_HOME"));
+        System.out.println("Expected runtime config = " +
+                new File(System.getenv("SIGMA_HOME"), "KBs/config.xml").getCanonicalPath());
+
+        if (!KBmanager.initialized) {
+            KBmanager.getMgr().initializeOnce();
         }
-        else {
-            System.out.println("IntegrationTestBase.setup(): reusing already initialized integration KB.");
-        }
-        kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getDefaultKbName());
-        if (kb == null)
-            throw new IllegalStateException("Could not get default KB after initialization.");
-        if (kbBackup == null)
-            kbBackup = new KB(kb);
+
+        kb = KBmanager.getMgr().getKB("SUMO");
+        kbBackup = new KB(kb);
+
         checkConfiguration();
+
         long endTime = System.currentTimeMillis();
-        if (IntegrationTestBase.totalKbMgrInitTime == Long.MAX_VALUE)
+
+        if (IntegrationTestBase.totalKbMgrInitTime == Long.MAX_VALUE) {
             IntegrationTestBase.totalKbMgrInitTime = endTime - startTime;
+        }
     }
     
     private static Configuration buildIntegrationConfiguration() {
 
+        String sigmaHome = System.getenv("SIGMA_HOME");
         String kbDir = KB_PATH;
+        String userHome = System.getProperty("user.home");
+
         Configuration config = new Configuration();
         config.clearKbConstituentLists();
-        config.setPreference("baseDir", System.getenv("SIGMA_HOME"));
-        config.setPreference("kbDir", kbDir);
-        config.setPreference("inferenceTestDir", kbDir + File.separator + "tests");
-        config.setPreference("loadFresh", "true");
-        config.setPreference("loadLexicons", "true");
-        config.setPreference("cache", "true");
-        config.setPreference("cacheDisjoint", "true");
-        config.setPreference("cwa", "false");
-        config.setPreference("maxPredicateArity", "6");
-        config.setPreference("graphVizExec", "/usr/bin/dot");
-        String userHome = System.getProperty("user.home");
+
         String eproverExec = new File("/usr/local/bin/e_ltb_runner").canExecute()
                 ? "/usr/local/bin/e_ltb_runner"
-                : userHome + File.separator + "Programs" + File.separator + "E" + File.separator + "PROVER" + File.separator + "e_ltb_runner";
+                : userHome + File.separator + "Programs" + File.separator + "E" +
+                File.separator + "PROVER" + File.separator + "e_ltb_runner";
+
         String vampireExec = new File("/usr/local/bin/vampire").canExecute()
                 ? "/usr/local/bin/vampire"
-                : userHome + File.separator + "Programs" + File.separator + "vampire" + File.separator + "build" + File.separator + "vampire";
+                : userHome + File.separator + "Programs" + File.separator + "vampire" +
+                File.separator + "build" + File.separator + "vampire";
+
+        config.setPreference("adminBrowserLimit", "200");
+        config.setPreference("baseDir", sigmaHome);
+        config.setPreference("cache", "yes");
+        config.setPreference("celtdir", "");
+        config.setPreference("editDir", kbDir);
+        config.setPreference("eprover", eproverExec);
         config.setPreference("eproverExec", eproverExec);
+        config.setPreference("graphVizDir", "/usr/bin");
+        config.setPreference("graphVizExec", "/usr/bin/dot");
+        config.setPreference("holdsPrefix", "no");
+        config.setPreference("hostname", "localhost");
+        config.setPreference("https", "false");
+        config.setPreference("imageFormat", "png");
+        config.setPreference("inferenceTestDir", kbDir + File.separator + "tests");
+        config.setPreference("jedit", "/usr/share/jedit/jedit");
+        config.setPreference("kbDir", kbDir);
+        config.setPreference("leoExecutable", userHome + File.separator + "leo");
+        config.setPreference("lineNumberCommand", "");
+        config.setPreference("loadCELT", "no");
+        config.setPreference("loadFresh", "false");
+        config.setPreference("logDir", sigmaHome + File.separator + "logs");
+        config.setPreference("logLevel", "warning");
+        config.setPreference("port", "8080");
+        config.setPreference("prolog", "");
+        config.setPreference("reportDup", "no");
+        config.setPreference("reportFnError", "no");
+        config.setPreference("showcached", "no");
+        config.setPreference("sumokbname", "SUMO");
+        config.setPreference("systemsDir", userHome);
+        config.setPreference("termFormats", "no");
+        config.setPreference("testOutputDir", System.getenv("CATALINA_HOME") +
+                File.separator + "webapps" + File.separator + "sigma" +
+                File.separator + "tests");
+        config.setPreference("TPTPDisplay", "no");
+        config.setPreference("tptpHomeDir", userHome);
+        config.setPreference("TPTP", "yes");
+        config.setPreference("typePrefix", "yes");
+        config.setPreference("userBrowserLimit", "25");
+        config.setPreference("vampire", vampireExec);
         config.setPreference("vampireExec", vampireExec);
-        config.setPreference("tptpExec", System.getProperty("user.home") + File.separator + "workspace" + File.separator + "TPTP4X" + File.separator + "tptp4X");
-        config.setPreference("systemsDir", System.getProperty("user.home"));
+
         List<String> constituents = Arrays.asList(
-            "english_format.kif",
-            "domainEnglishFormat.kif",
-            "Merge.kif",
-            "Mid-level-ontology.kif",
-            "ArabicCulture.kif",
-            "Cars.kif",
-            "Catalog.kif",
-            "Communications.kif",
-            "CountriesAndRegions.kif",
-            "Dining.kif",
-            "Economy.kif",
-            "engineering.kif",
-            "FinancialOntology.kif",
-            "Food.kif",
-            "Geography.kif",
-            "Government.kif",
-            "Hotel.kif",
-            "Justice.kif",
-            "Languages.kif",
-            "Media.kif",
-            "MilitaryDevices.kif",
-            "Military.kif",
-            "MilitaryPersons.kif",
-            "MilitaryProcesses.kif",
-            "Music.kif",
-            "naics.kif",
-            "People.kif",
-            "QoSontology.kif",
-            "Sports.kif",
-            "TransnationalIssues.kif",
-            "Transportation.kif",
-            "TransportDetail.kif",
-            "VirusProteinAndCellPart.kif",
-            "WMD.kif"
+                "english_format.kif",
+                "domainEnglishFormat.kif",
+                "ArabicCulture.kif",
+                "Anatomy.kif",
+                "arteries.kif",
+                "Biography.kif",
+                "Cars.kif",
+                "Catalog.kif",
+                "Communications.kif",
+                "CountriesAndRegions.kif",
+                "Dining.kif",
+                "Economy.kif",
+                "emotion.kif",
+                "engineering.kif",
+                "Facebook.kif",
+                "FinancialOntology.kif",
+                "Food.kif",
+                "Geography.kif",
+                "Government.kif",
+                "Hotel.kif",
+                "Justice.kif",
+                "Languages.kif",
+                "Law.kif",
+                "Media.kif",
+                "Medicine.kif",
+                "Merge.kif",
+                "Mid-level-ontology.kif",
+                "MilitaryDevices.kif",
+                "Military.kif",
+                "MilitaryPersons.kif",
+                "MilitaryProcesses.kif",
+                "Music.kif",
+                "naics.kif",
+                "People.kif",
+                "pictureList.kif",
+                "pictureList-ImageNet.kif",
+                "QoSontology.kif",
+                "Sports.kif",
+                "TransnationalIssues.kif",
+                "Transportation.kif",
+                "TransportDetail.kif",
+                "UXExperimentalTerms.kif",
+                "VirusProteinAndCellPart.kif",
+                "Weather.kif",
+                "WMD.kif"
         );
+
         config.setKbConstituentList("SUMO", constituents);
         return config;
     }

--- a/src/test/unit/java/com/articulate/nlp/SigmaTestBase.java
+++ b/src/test/unit/java/com/articulate/nlp/SigmaTestBase.java
@@ -17,32 +17,6 @@ public class SigmaTestBase {
 
     protected static KB kb;
 
-    // /****************************************************************
-    //  * Performs the KB load.
-    //  * @param reader
-    //  */
-    // protected static void doSetUp(Reader reader) {
-
-    //     SimpleElement configuration = null;
-    //     if (!KBmanager.initialized) {
-    //         try {
-    //             SimpleDOMParser sdp = new SimpleDOMParser();
-    //             //sdp.setSkipProlog(false);
-    //             configuration = sdp.parse(reader);
-    //         }
-    //         catch (IOException e) {
-    //             e.printStackTrace();
-    //         }
-
-    //         KBmanager.getMgr().setDefaultAttributes();
-    //         // KBmanager.getMgr().setConfiguration(configuration);
-    //         KBmanager.getMgr().initializeOnce();
-    //         KBmanager.initialized = true;
-    //     }
-    //     kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
-    //     checkConfiguration();
-    // }
-
     /****************************************************************
      * Performs the KB load.
      * @param reader
@@ -50,25 +24,11 @@ public class SigmaTestBase {
     protected static void doSetUp() {
 
         if (!KBmanager.initialized) {
-            // try {
-                // File sourceConfig = new File(configPath);
-                // File kbDir = new File(KB_PATH);
-                // File targetConfig = new File(kbDir, "config.xml");
-                // kbDir.mkdirs();
-                // java.nio.file.Files.copy(
-                //         sourceConfig.toPath(),
-                //         targetConfig.toPath(),
-                //         java.nio.file.StandardCopyOption.REPLACE_EXISTING
-                // );
-                Configuration config = buildUnitConfiguration();
-                KBmanager.initialized = false;
-                KBmanager.initializing = false;
-                KBmanager.getMgr().kbs.clear();
-                KBmanager.getMgr().initializeOnce(config);
-            // }
-            // catch (IOException e) {
-            //     throw new RuntimeException("Could not prepare Sigma test config", e);
-            // }
+            Configuration config = buildUnitConfiguration();
+            KBmanager.initialized = false;
+            KBmanager.initializing = false;
+            KBmanager.getMgr().kbs.clear();
+            KBmanager.getMgr().initializeOnce(config);
         }
         kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getDefaultKbName());
         checkConfiguration();


### PR DESCRIPTION
Fixed failed integration tests by only adding 4 constituents to the in-memory configuration. Also set loadFresh to true and cache to false.